### PR TITLE
fix link in admin pages

### DIFF
--- a/bank_answer/src/main/resources/application.yml
+++ b/bank_answer/src/main/resources/application.yml
@@ -4,12 +4,12 @@ spring:
   kafka:
     consumer:
       auto-offset-reset: earliest
-      bootstrap-servers: kafka:9092
+      bootstrap-servers: localhost:9092
       group-id: app.1
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
     producer:
-      bootstrap-servers: kafka:9092
+      bootstrap-servers: localhost:9092
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
   mvc:

--- a/credit_system/src/main/resources/application.properties
+++ b/credit_system/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 server.port=8085
 
-spring.datasource.url=jdbc:postgresql://postgres:5432/creditsys
+spring.datasource.url=jdbc:postgresql://localhost:5432/creditsys
 spring.datasource.username=postgres
 spring.datasource.password=123
 
@@ -19,10 +19,10 @@ spring.liquibase.enabled=true
 #spring.mvc.view.suffix=.jsp
 
 spring.kafka.consumer.group-id=app.1
-spring.kafka.consumer.bootstrap-servers=kafka:9092
+spring.kafka.consumer.bootstrap-servers=localhost:9092
 spring.kafka.consumer.auto-offset-reset=earliest
 spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
 spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.StringDeserializer
-spring.kafka.producer.bootstrap-servers=kafka:9092
+spring.kafka.producer.bootstrap-servers=localhost:9092
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer

--- a/credit_system/src/main/resources/hibernate.cfg.xml
+++ b/credit_system/src/main/resources/hibernate.cfg.xml
@@ -12,7 +12,7 @@
         </property>
 
         <property name="hibernate.connection.url">
-            jdbc:postgresql://postgres:5432/creditsys
+            jdbc:postgresql://localhost:5432/creditsys
         </property>
         <property name="hibernate.connection.username">
             postgres

--- a/credit_system/src/main/resources/templates/admin/bank.html
+++ b/credit_system/src/main/resources/templates/admin/bank.html
@@ -6,7 +6,7 @@
 </head>
 
 <body>
-<p><a href="#" onclick="javascript:history.back();return false" title="Назад">Назад</а></p>
+<p><a href="#" onclick="javascript:history.back();return false" title="Назад">Назад</a></p>
 <h1>Банк: <span th:text="${bank.bankName}"></span></h1>
 <!--Thymeleaf modified page-->
 <table border="1">

--- a/credit_system/src/main/resources/templates/admin/bankss.html
+++ b/credit_system/src/main/resources/templates/admin/bankss.html
@@ -5,7 +5,7 @@
     <title>Банки</title>
 </head>
 <body>
-<p><a href="#" onclick="javascript:history.back();return false" title="Назад">Назад</а></p>
+<p><a href="#" onclick="javascript:history.back();return false" title="Назад">Назад</a></p>
 <h1>Список всех банков</h1>
 <!--Thymeleaf modified page-->
 <table border="1">

--- a/credit_system/src/main/resources/templates/admin/client.html
+++ b/credit_system/src/main/resources/templates/admin/client.html
@@ -6,7 +6,7 @@
 </head>
 
 <body>
-<p><a href="#" onclick="javascript:history.back();return false" title="Назад">Назад</а></p>
+<p><a href="#" onclick="javascript:history.back();return false" title="Назад">Назад</a></p>
 <h1>Клиент: <span th:text="${client.fullName}"></span></h1>
 <!--Thymeleaf modified page-->
 <table border="1">

--- a/credit_system/src/main/resources/templates/admin/clients.html
+++ b/credit_system/src/main/resources/templates/admin/clients.html
@@ -5,7 +5,7 @@
     <title>Клиенты</title>
 </head>
 <body>
-<p><a href="#" onclick="javascript:history.back();return false" title="Назад">Назад</а></p>
+<p><a href="#" onclick="javascript:history.back();return false" title="Назад">Назад</a></p>
 <h1>Список всех клиентов</h1>
 <!--Thymeleaf modified page-->
 <table border="1">

--- a/credit_system/src/main/resources/templates/admin/credit.html
+++ b/credit_system/src/main/resources/templates/admin/credit.html
@@ -6,7 +6,7 @@
 </head>
 
 <body>
-<p><a href="#" onclick="javascript:history.back();return false" title="Назад">Назад</а></p>
+<p><a href="#" onclick="javascript:history.back();return false" title="Назад">Назад</a></p>
 <h1>Кредит: <span th:text="${credit.id}"></span></h1>
 <!--Thymeleaf modified page-->
 <table border="1">

--- a/credit_system/src/main/resources/templates/admin/credits.html
+++ b/credit_system/src/main/resources/templates/admin/credits.html
@@ -5,7 +5,7 @@
     <title>Кредиты</title>
 </head>
 <body>
-<p><a href="#" onclick="javascript:history.back();return false" title="Назад">Назад</а></p>
+<p><a href="#" onclick="javascript:history.back();return false" title="Назад">Назад</a></p>
 <h1>Список кредитных предложений</h1>
 <!-- Thymeleaf modified page -->
 <table border="1">

--- a/credit_system/src/main/resources/templates/admin/statistic.html
+++ b/credit_system/src/main/resources/templates/admin/statistic.html
@@ -27,7 +27,7 @@
             border-width:1px;
         }
         a{
-            color:black;
+            color:floralwhite;
         }
     </style>
 </head>


### PR DESCRIPTION
В админской ветке на страницах с банками, клиентами и предложениями закрывающий тег на ссылку "назад" был указан кириллицей, поэтому вся таблица превращалась в ссылку.
исправлено. Проверьте, подтвердите